### PR TITLE
feat : Support custom timestamp and file permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ type Logger struct {
     // Compress determines if the rotated log files should be compressed
     // using gzip. The default is not to perform compression.
     Compress bool `json:"compress" yaml:"compress"`
+    
+    // TimeFormat determines the format to use for formatting the timestamp in
+    // backup files. The default format is defined in `DefaultTimeFormat`.
+    TimeFormat string `json:"timeformat" yaml:"timeformat"`
+
     // contains filtered or unexported fields
 }
 ```


### PR DESCRIPTION
## Issue Link
- https://lunit.atlassian.net/browse/CXR316X-902
- https://lunit.atlassian.net/browse/CXR316X-950

## What's the purpose?
- lumberjack 오픈소스에서 아래 기능을 지원하지 않아서 fork해서 수정합니다.
 - 백업 파일명 생성 시 사용자 지정 timestamp 파라미터 추가
 - 백업 파일 생성 시 0600 -> 0644 권한으로 생성하도록 수정

## How do you solve it?

> Please fill out how you modified it in this issue.

## How can the reviewer check it?

> Please write about how to check the revised contents in this issue.

## Do you have attachments?

> Please fill out any images, document links, or files that can help review this issue.

## Is this a breaking change?

- [ ] Yes
- [X] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
