### PR TITLE
Edit timeFromName to fix extrating time format logic from logfile name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# mac os
+.idea
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -450,6 +450,10 @@ func (l *Logger) timeFromName(filename, prefix, ext string) (time.Time, error) {
 		return time.Time{}, errors.New("mismatched extension")
 	}
 	ts := filename[len(prefix) : len(filename)-len(ext)]
+	split := strings.Split(ts, "-")
+	if len(split) == 4 {
+		ts = strings.Join(split[1:], "-")
+	}
 	return time.Parse(l.timeFormat(), ts)
 }
 


### PR DESCRIPTION
timeFromName에서 timeformat을 제대로 Parsing하지 못하는 현상 수정

timeFromName 함수로 prefix가 전달 될 때 아래와 같은 2가지 형식으로 전달됨 (해당 로직은 비동기로 실행 됨)
* APP-CXRT-
* APP-CXRT-debug- 

기존 로직에서는 additional log level이 info면 APP-CXRT-info- 로 전달되어서, APP-CXRT-debug- 로 시작되는 file은 삭제가 안됨

prefix로 `APP-CXRT-` 가 넘어올 때
* `APP-CXRT-2024-01-02.log` 와 같은 로그 파일의 날짜만 parsing이 되고 
* `APP-CXRT-info-2024-01-02.log` 와 같은 파일 명은 날짜를 뽑아내는 로직에서 `info-2024-01-02`로 뽑히기 때문에 parsing이 안됨 -> parsing이 안되면 삭제 대상이 되는 slice에 추가가 안된다.

prefix로 `APP-CXRT-info-` 가 넘어올 때
* 이 때 `APP-CXRT-info-2024-01-02.log` 와 같은 파일명 에서 날짜를 뽑아내어 삭제 대상이 되는 slice에 추가가 되고 ->  additional log 파일이 삭제가 됨

추가한 로직은 prefix로 `APP-CXRT-` 가 넘어올 때 additional log file의 경우 `info-2024-01-02` 이런 식으로 날짜가 뽑히는 경우에만 골라서 제대로 날짜를 parsing할 수 있도록 통과 시켜서 삭제 대상이 되는 slice에 파일을 모두 추가하게끔 처리한다.